### PR TITLE
Prepare for new cross build settings

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,9 +14,9 @@ class CygwinInstallerConan(ConanFile):
     description = "Cygwin is a distribution of popular GNU and other Open Source tools running on Microsoft Windows"
     url = "https://github.com/bincrafters/conan-cygwin_installer"
     if conan_version < Version("0.99"):
-        settings = "os", "arch"
+        settings = {"os": ["Windows"], "arch": ["x86", "x86_64"]}
     else:
-        settings = "os_build", "arch_build"
+        settings = {"os_build": ["Windows"], "arch_build": ["x86", "x86_64"]}
     install_dir = 'cygwin-install'
     short_paths = True
     options = {"additional_packages": "ANY"}
@@ -29,10 +29,6 @@ class CygwinInstallerConan(ConanFile):
     @property
     def arch(self):
         return self.settings.get_safe("arch_build") or self.settings.get_safe("arch")
-
-    def configure(self):
-        if self.os != "Windows":
-            raise Exception("Only windows supported")
 
     def build(self):
         filename = "setup-%s.exe" % self.arch


### PR DESCRIPTION
In Conan 1.0.0 beta, we are going to introduce a couple of new settings `os_build` and `arch_build`, specially designed for cross building. They mean "where Conan will run". Translating this concept to installers, these settings are used to know where to install a tool, so we use `os_build` and `arch_build` instead of `os` and `arch` that will indicate the system where the product of the compilation will run. There is a lot of pending docs to write next week, I want to dedicate a section to this.

This cygwin installer is no the best example to indicate the value of the `os_build` and `arch_build` but imagine the `cmake_installer`. CMake is installed in Windows, (I indicate this with "os_build") but then it can be used to cross build to linux (I indicate this with `os`), there is no more need of using detection tools, now is always declarative, as we always wanted Conan to be.

In general, for all the tools, would be nice if you can change it to use "os_build" and "arch_build" it has more sense to me. In this PR I try to keep the compatibility with previous conan versions.

I also add an option to install more components, I don't know if you like it or not, just an idea.